### PR TITLE
Enhanced documentation for presets with trackNo and elapsedTime

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,8 @@ Example content:
       "volume": 15
     }
   ],
+  "trackNo": 3,
+  "elapsedTime": 42,
   "playMode": {
     "shuffle": true,
     "repeat": "all",


### PR DESCRIPTION
Added trackNo and elapsedTime to preset documentation, as they are supported but not documented. I had to dig in the code to find this and want to make it easier for people with the same needs. 